### PR TITLE
Run custom build

### DIFF
--- a/integration-tests/integration-tests-kogito-plugin/pom.xml
+++ b/integration-tests/integration-tests-kogito-plugin/pom.xml
@@ -20,6 +20,7 @@
       <plugin>
         <artifactId>maven-invoker-plugin</artifactId>
         <configuration>
+          <streamLogs>true</streamLogs>
           <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
           <settingsFile>src/it/settings.xml</settingsFile>
           <localRepositoryPath>${project.build.directory}/local-repo</localRepositoryPath>

--- a/integration-tests/integration-tests-kogito-plugin/src/it/integration-tests-kogito-plugin-it/invoker.properties
+++ b/integration-tests/integration-tests-kogito-plugin/src/it/integration-tests-kogito-plugin-it/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = clean compile org.kie.kogito:kogito-maven-plugin:generateModel package  -Dkogito.codegen.sources.directory=src/main/java 

--- a/integration-tests/integration-tests-kogito-plugin/src/it/integration-tests-kogito-plugin-it/pom.xml
+++ b/integration-tests/integration-tests-kogito-plugin/src/it/integration-tests-kogito-plugin-it/pom.xml
@@ -7,10 +7,6 @@
     </parent>
     <artifactId>integration-tests-kogito-plugin-it</artifactId>
 
-    <properties>
-        <kogito.codegen.sources.directory>src/main/generated</kogito.codegen.sources.directory>
-    </properties>
-
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/integration-tests/integration-tests-kogito-plugin/src/it/integration-tests-kogito-plugin-it/pom.xml
+++ b/integration-tests/integration-tests-kogito-plugin/src/it/integration-tests-kogito-plugin-it/pom.xml
@@ -73,9 +73,7 @@
                 <artifactId>quarkus-maven-plugin</artifactId>
                 <executions>
                     <execution>
-                        <goals>
-                            <goal>build</goal>
-                        </goals>
+                        <phase>none</phase>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
the test case was still building in target/generated-sources. Now it should be configured properly